### PR TITLE
fix: export `EventListenerArguments` interface

### DIFF
--- a/src/EventSequenceListener/EventSequenceListener.interface.ts
+++ b/src/EventSequenceListener/EventSequenceListener.interface.ts
@@ -133,7 +133,7 @@ export interface GeneralConfig {
   promiseQueueMax?: number
 }
 
-interface EventListenerArguments {
+export interface EventListenerArguments {
   eventName: string
   arguments: any[]
 }


### PR DESCRIPTION
tsc was unable to create the definition files
because the interface name can not be found.